### PR TITLE
TDVF: support TDP vTPM in IntelTdxX64 target

### DIFF
--- a/OvmfPkg/Library/PeilessStartupLib/PeilessStartup.c
+++ b/OvmfPkg/Library/PeilessStartupLib/PeilessStartup.c
@@ -86,7 +86,7 @@ InitializePlatform (
     PlatformInitEmuVariableNvStore (VariableStore);
   }
 
-  if (TdIsEnabled ()) {
+  if (TdIsEnabled () && !TdpIsEnabled ()) {
     PlatformTdxPublishRamRegions ();
   } else {
     PlatformQemuInitializeRam (PlatformInfoHob);
@@ -109,7 +109,9 @@ InitializePlatform (
   if (TdIsEnabled ()) {
     PlatformInfoHob->PcdConfidentialComputingGuestAttr = CCAttrIntelTdx;
     PlatformInfoHob->PcdTdxSharedBitMask               = TdSharedPageMask ();
-    PlatformInfoHob->PcdSetNxForStack                  = TRUE;
+    if (!TdpIsEnabled ()) {
+      PlatformInfoHob->PcdSetNxForStack                  = TRUE;
+    }
   }
 
   PlatformMiscInitialization (PlatformInfoHob);
@@ -148,7 +150,7 @@ PeilessStartup (
 
   ZeroMem (&PlatformInfoHob, sizeof (PlatformInfoHob));
 
-  if (TdIsEnabled ()) {
+  if (TdIsEnabled () && !TdpIsEnabled ()) {
     VmmHobList = (VOID *)(UINTN)FixedPcdGet32 (PcdOvmfSecGhcbBase);
     Status     = TdCall (TDCALL_TDINFO, 0, 0, 0, &TdReturnData);
     ASSERT (Status == EFI_SUCCESS);

--- a/OvmfPkg/Tcg/TdTcg2Dxe/TdTcg2Dxe.c
+++ b/OvmfPkg/Tcg/TdTcg2Dxe/TdTcg2Dxe.c
@@ -2430,7 +2430,7 @@ DriverEntry (
   EFI_EVENT   Event;
   VOID        *Registration;
 
-  if (!TdIsEnabled ()) {
+  if (!TdIsEnabled () || TdpIsEnabled ()) {
     return EFI_UNSUPPORTED;
   }
 


### PR DESCRIPTION
OvmfPkg/IntelTDX: Workaround in IntelTDX for TDP
- Due to the lack of support for TD HOB in TDP, work around them.
- Due to the lack of support for tdcall leaf 2 TdExtendRTMR, work around CC measurement.